### PR TITLE
remove jwt token when users signs out

### DIFF
--- a/src/components/ConnectButton/ConnectButton.tsx
+++ b/src/components/ConnectButton/ConnectButton.tsx
@@ -127,7 +127,9 @@ export const ConnectButton: FC<ConnectButtonProps> = ({
             <div
               className='p-2 hover:bg-[#F7F7F9] rounded-lg'
               onClick={() => {
-                localStorage.getItem('token');
+                // localStorage.getItem('token');
+                // remove jwt token once user signs out
+                localStorage.removeItem('token');
                 disconnect();
               }}
             >


### PR DESCRIPTION
https://qacc.atlassian.net/browse/QACC-407



i am not able to reproduce the issue but i think it can be because of the local storage had the old jwt token saved…i have updated the code to delete the jwt token when user clicks sign out.
