### PR TITLE
show the message only for swap

### DIFF
--- a/src/components/DonatePage/DonateSuccessPage.tsx
+++ b/src/components/DonatePage/DonateSuccessPage.tsx
@@ -274,12 +274,13 @@ const DonateSuccessPage: FC<IDonateSuccessPage> = ({
                       </svg>
                     </div>
                   </div>
-                  {pointsEarned === null && (
-                    <div className='border-t mt-2 p-2 text-redHatText text-gray-600 font-normal text-sm'>
-                      Your points are being calculated and will be added to your
-                      account once the transaction is confirmed.
-                    </div>
-                  )}
+                  {pointsEarned === null &&
+                    donationStatus === DonationStatus.Swap_pending && (
+                      <div className='border-t mt-2 p-2 text-redHatText text-gray-600 font-normal text-sm'>
+                        Your points are being calculated and will be added to
+                        your account once the transaction is confirmed.
+                      </div>
+                    )}
                 </div>
               </div>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the donation success page so that the "points being calculated" message now appears only when the donation is pending. This change ensures that you receive accurate feedback about your donation status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->