### PR TITLE
hide privado text and show leaderboard

### DIFF
--- a/src/components/DonatePage/DonateSuccessPage.tsx
+++ b/src/components/DonatePage/DonateSuccessPage.tsx
@@ -257,13 +257,7 @@ const DonateSuccessPage: FC<IDonateSuccessPage> = ({
 
                 <div className='border border-gray-300 bg-white rounded-lg font-redHatText text-gray-800 font-semibold leading-6 p-4'>
                   <div className='flex justify-between items-center '>
-                    <div>
-                      <span className=' '>q/acc points you've earned</span>
-                    </div>
-                    <div className='flex gap-2 items-center'>
-                      <span>
-                        {pointsEarned ? pointsEarned : '⏳ Calculating...'}
-                      </span>
+                    <div className='flex gap-1 items-center'>
                       <svg
                         xmlns='http://www.w3.org/2000/svg'
                         width='32'
@@ -277,15 +271,22 @@ const DonateSuccessPage: FC<IDonateSuccessPage> = ({
                           fill='white'
                         />
                       </svg>
+                      <span className=' '>You've earned q/acc points</span>
+                    </div>
+                    <div className='flex gap-2 items-center'>
+                      <span className='font-semibold text-giv-500 '>
+                        {/* {pointsEarned ? pointsEarned : '⏳ Calculating...'} */}
+                        <Link href={'/leaderboard'}>Check leaderboard</Link>
+                      </span>
                     </div>
                   </div>
-                  {pointsEarned === null &&
+                  {/* {pointsEarned === null &&
                     donationStatus === DonationStatus.Swap_pending && (
                       <div className='border-t mt-2 p-2 text-redHatText text-gray-600 font-normal text-sm'>
                         Your points are being calculated and will be added to
                         your account once the transaction is confirmed.
                       </div>
-                    )}
+                    )} */}
                 </div>
               </div>
 

--- a/src/components/PrivadoHoldUp.tsx
+++ b/src/components/PrivadoHoldUp.tsx
@@ -32,7 +32,7 @@ export const PrivadoHoldUp = () => {
           . Documents must include your date of birth or verification will fail.
           Have your document ready!
         </li>
-        <li>
+        {/* <li>
           <span className='text-gray-800 font-bold'>
             We strongly encourage you to use MetaMask at this time.
           </span>{' '}
@@ -46,7 +46,7 @@ export const PrivadoHoldUp = () => {
           </span>{' '}
           at this time. You will see an option to  “Continue via app” during
           verification. Do not select that.
-        </li>
+        </li> */}
       </ul>
     </>
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the Donate Success page to display an icon and a link to the leaderboard instead of showing the exact number of q/acc points earned.
  - Removed the message about points being calculated during pending donations.
  - Removed recommendations regarding MetaMask and the Privado mobile app from the Privado Hold Up page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->