### PR TITLE
change zkid texts

### DIFF
--- a/src/components/DonatePage/EligibilityCheckToast.tsx
+++ b/src/components/DonatePage/EligibilityCheckToast.tsx
@@ -1,8 +1,6 @@
 /* eslint-disable prettier/prettier */
 import React from 'react';
-import floor from 'lodash/floor';
 import { useFetchActiveRoundDetails } from '@/hooks/useFetchActiveRoundDetails';
-import { formatAmount } from '@/helpers/donation';
 
 export const EligibilityCheckToast = () => {
   const { data: activeRoundDetails } = useFetchActiveRoundDetails();

--- a/src/components/DonatePage/EligibilityCheckToast.tsx
+++ b/src/components/DonatePage/EligibilityCheckToast.tsx
@@ -31,14 +31,11 @@ export const EligibilityCheckToast = () => {
         <ul className='list-disc px-4'>
           <li>
             {' '}
-            With <span className='font-bold'>Human Passport</span>, you are
-            eligible to support each project with up to{' '}
-            {formatAmount(floor(Number(low_cap)))} POL .
+            You can spend approximately $1,000 when verified with Human
+            Passport.
           </li>
           <li>
-            With <span className='font-bold'>Privado zkID credentials</span>,
-            you are eligible to support each project with up to{' '}
-            {formatAmount(floor(Number(high_cap)))} POL .
+            You can spend approximately $25,000 when verified with Privado zkID.
           </li>
         </ul>
       </p>

--- a/src/components/Verification/GitcoinVerifySection.tsx
+++ b/src/components/Verification/GitcoinVerifySection.tsx
@@ -56,10 +56,7 @@ export const GitcoinVerifySection = () => {
     <section className='bg-gray-50 rounded-2xl p-6 flex gap-4 justify-between'>
       <div>
         <h1 className='text-lg font-bold'>Human Passport</h1>
-        <p>
-          You are eligible to support each project with up to&nbsp;
-          {formatAmount(low_cap)} POL.
-        </p>
+        <p>Your verification allows you to spend up to approximately $1,000.</p>
       </div>
       <div>
         {!isVerified && (
@@ -71,9 +68,7 @@ export const GitcoinVerifySection = () => {
     <section className='relative overflow-hidden bg-gray-50 rounded-2xl p-6 flex flex-col gap-4'>
       <h1 className='text-lg font-bold'>Human Passport</h1>
       <p>
-        Verify your uniqueness with Human Passport to support each project with
-        up to&nbsp;
-        {formatAmount(low_cap)} POL.
+        This verification would allow you to spend up to approximately $1,000.
       </p>
       <Button
         styleType={ButtonStyle.Solid}
@@ -89,7 +84,7 @@ export const GitcoinVerifySection = () => {
     <section className='relative overflow-hidden bg-gray-50 rounded-2xl p-6 flex flex-col gap-4'>
       <h1 className='text-lg font-bold'>Human Passport</h1>
       <p>
-        To support each project with up to {formatAmount(low_cap)} POL, you must
+        To support each project with up to $,1000, you must
         <b className='font-bold'>
           &nbsp;increase your Human Passport score to&nbsp;
           {config.GP_SCORER_SCORE_THRESHOLD}

--- a/src/components/Verification/ZkidVerifySection.tsx
+++ b/src/components/Verification/ZkidVerifySection.tsx
@@ -9,7 +9,6 @@ import {
 } from '@/components/EligibilityBadge';
 import { useFetchAllRound } from '@/hooks/useFetchAllRound';
 import { IQfRound } from '@/types/round.type';
-import { formatAmount } from '@/helpers/donation';
 
 export const ZkidVerifySection = () => {
   const [showPrivadoModal, setShowPrivadoModal] = useState(false);

--- a/src/components/Verification/ZkidVerifySection.tsx
+++ b/src/components/Verification/ZkidVerifySection.tsx
@@ -34,8 +34,7 @@ export const ZkidVerifySection = () => {
       <div>
         <h1 className='text-lg font-bold'>Privado zkID</h1>
         <p>
-          You are eligible to support each project with up to{' '}
-          {formatAmount(high_cap)} POL.
+          Your verification allows you to spend up to approximately $25,000.
         </p>
       </div>
       <div>
@@ -46,8 +45,7 @@ export const ZkidVerifySection = () => {
     <section className='bg-gray-50 rounded-2xl p-6 flex flex-col gap-4'>
       <h1 className='text-lg font-bold'>Privado zkID</h1>
       <p>
-        Get your credentials with Privado zkID to support each project with up
-        to {formatAmount(high_cap)} POL.
+        This verification would allow you to spend up to approximately $25,000.
       </p>
       <Button
         styleType={ButtonStyle.Solid}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated eligibility and spending limit messages to display fixed approximate dollar amounts ($1,000 and $25,000) instead of dynamic POL token values across relevant sections.
  - Simplified user-facing text for eligibility caps to improve clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->