### PR TITLE
chnaged dollar values first

### DIFF
--- a/src/components/DonarDashboard/DonarSupportedProjects.tsx
+++ b/src/components/DonarDashboard/DonarSupportedProjects.tsx
@@ -13,7 +13,6 @@ import { IconMinted } from '../Icons/IconMinted';
 import { IconAvailableTokens } from '../Icons/IconAvailableTokens';
 import { Button, ButtonColor } from '../Button';
 import { IconBreakdownArrow } from '../Icons/IconBreakdownArrow';
-import { useFetchTokenPrice } from '@/hooks/useFetchTokenPrice';
 import {
   useTokenPriceRange,
   useTokenPriceRangeStatus,

--- a/src/components/DonarDashboard/DonarSupportedProjects.tsx
+++ b/src/components/DonarDashboard/DonarSupportedProjects.tsx
@@ -26,6 +26,7 @@ import { EProjectSocialMediaType, IProject } from '@/types/project.type';
 import { IconShare } from '../Icons/IconShare';
 import { ShareProjectModal } from '../Modals/ShareProjectModal';
 import { useTokenSupplyDetails } from '@/hooks/useTokenSupplyDetails';
+import { useFetchPOLPriceSquid } from '@/hooks/useFetchPOLPriceSquid';
 
 const DonarSupportedProjects = ({
   projectId,
@@ -48,7 +49,7 @@ const DonarSupportedProjects = ({
   totalRewardTokens: number;
   onClickBreakdown: () => void;
 }) => {
-  const { data: POLPrice } = useFetchTokenPrice();
+  const { data: POLPrice } = useFetchPOLPriceSquid();
   const { data: activeRoundDetails } = useFetchActiveRoundDetails();
   const [maxPOLCap, setMaxPOLCap] = useState(0);
   const [isShareModalOpen, setIsShareModalOpen] = useState(false);
@@ -233,12 +234,12 @@ const DonarSupportedProjects = ({
               <IconTotalDonations size={24} />
               <span className='font-medium text-[#1D1E1F]'>Total received</span>
             </div>
-            <div className='flex gap-1'>
+            <div className='flex gap-2'>
               <span className='font-medium text-[#1D1E1F]'>
-                {formatAmount(totalContributions) || 0} POL{' '}
+                ~ $ {formatAmount(totalContributions * POLPrice) || 0}
               </span>
               <span className='font-medium text-[#82899A]'>
-                ~ $ {formatAmount(project.totalDonations) || 0}
+                {formatAmount(totalContributions) || 0} POL{' '}
               </span>
             </div>
           </div>

--- a/src/components/DonarDashboard/MyProjects.tsx
+++ b/src/components/DonarDashboard/MyProjects.tsx
@@ -570,15 +570,15 @@ const MyProjects = () => {
                   </div>
                 </div>
               </div>
-              <div className='flex gap-1'>
+              <div className='flex gap-2'>
                 <span className='font-medium text-[#1D1E1F]'>
-                  {formatAmount(claimedTributes)} POL
-                </span>
-                <span className='font-medium text-[#82899A]'>
                   ~ ${' '}
                   {formatAmount(
                     Math.round(claimedTributes * Number(POLPrice) * 100) / 100,
                   )}
+                </span>
+                <span className='font-medium text-[#82899A]'>
+                  {formatAmount(claimedTributes)} POL
                 </span>
               </div>
             </div>
@@ -597,16 +597,16 @@ const MyProjects = () => {
                   </div>
                 </div>
               </div>
-              <div className='flex gap-1'>
+              <div className='flex gap-2'>
                 <span className='font-medium text-[#1D1E1F]'>
-                  {formatAmount(claimableFeesFormated)} POL
-                </span>
-                <span className='font-medium text-[#82899A]'>
                   ~ ${' '}
                   {formatAmount(
                     Math.round(claimableFeesFormated * Number(POLPrice) * 100) /
                       100,
                   )}
+                </span>
+                <span className='font-medium text-[#82899A]'>
+                  {formatAmount(claimableFeesFormated)} POL
                 </span>
               </div>
             </div>
@@ -693,13 +693,13 @@ const MyProjects = () => {
 
           <div className='flex items-center gap-4'>
             <span className='text-[#1D1E1F] font-bold text-[25px]'>
-              {formatAmount(totalAmountDonated)} POL
-            </span>
-            <span className='text-[#1D1E1F]  font-medium'>
               ~ ${' '}
               {formatAmount(
                 Math.round(totalAmountDonated * Number(POLPrice) * 100) / 100,
               )}
+            </span>
+            <span className='text-[#1D1E1F]  font-medium'>
+              {formatAmount(totalAmountDonated)} POL
             </span>
           </div>
         </div>

--- a/src/components/DonarDashboard/ProjectUserDonationTable.tsx
+++ b/src/components/DonarDashboard/ProjectUserDonationTable.tsx
@@ -203,12 +203,12 @@ const ProjectUserDonationTable: React.FC<ProjectUserDonationTableProps> = ({
             All your contributions
           </h1>
         </div>
-        <div className='flex gap-2 text-[#1D1E1F] '>
-          <h1 className='md:text-[25px] font-bold '>
-            {formatAmount(totalContributions)} POL
+        <div className='flex gap-2 text-[#1D1E1F] justify-center items-center '>
+          <h1 className='md:text-[24px] font-bold '>
+            ~ $ {formatAmount(totalContributions * Number(POLPrice))}
           </h1>
           <span className='font-medium'>
-            ~ ${formatAmount(totalContributions * Number(POLPrice))}
+            {formatAmount(totalContributions)} POL
           </span>
         </div>
       </div>

--- a/src/components/DonarDashboard/RewardsBreakDown.tsx
+++ b/src/components/DonarDashboard/RewardsBreakDown.tsx
@@ -126,12 +126,12 @@ const RewardsBreakDown: React.FC = () => {
                   Total received
                 </span>
               </div>
-              <div className='flex gap-1'>
+              <div className='flex gap-2'>
                 <span className='font-medium text-[#1D1E1F]'>
-                  {formatAmount(totalContributions)} POL
+                  ~ ${formatAmount(totalContributions * Number(POLPrice)) || 0}
                 </span>
                 <span className='font-medium text-[#82899A]'>
-                  ~ ${formatAmount(totalContributions * Number(POLPrice)) || 0}
+                  {formatAmount(totalContributions)} POL
                 </span>
               </div>
             </div>

--- a/src/components/DonatePage/DonatePageBody.tsx
+++ b/src/components/DonatePage/DonatePageBody.tsx
@@ -1179,13 +1179,13 @@ const DonatePageBody: React.FC<DonatePageBodyProps> = ({ setIsConfirming }) => {
               </h2>
               <div className='flex gap-2 items-center'>
                 <h1 className='text-4xl font-extrabold p-2'>
-                  {formatAmount(totalPOLDonated)} POL
-                </h1>
-                <h2 className='text-[#1D1E1F] font-medium'>
                   ~ ${' '}
                   {formatAmount(
                     Math.round(totalPOLDonated * Number(POLPrice) * 100) / 100,
                   )}
+                </h1>
+                <h2 className='text-[#1D1E1F] font-medium'>
+                  {formatAmount(totalPOLDonated)} POL
                 </h2>
               </div>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the display order of POL token amounts and their USD equivalents across various dashboard and donation sections, now showing the USD value first followed by the POL amount.
  - Increased spacing between token and USD values for improved readability.
  - Adjusted alignment and font sizes for a more consistent user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->